### PR TITLE
Link GitHub source in page header

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -95,6 +95,13 @@ html_static_path = ['_static']
 html_favicon = 'favicon.ico'
 html_logo = 'header.png'
 
+html_context = {
+  'display_github': True,
+  'github_user': 'SoMainline',
+  'github_repo': 'docs.somainline.org',
+  'github_version': 'master/source/',
+}
+
 # -- Extension configuration -------------------------------------------------
 
 # -- Options for intersphinx extension ---------------------------------------


### PR DESCRIPTION
This replaces the 'View page source' with 'Edit on GitHub' so users can
quickly go to actual sources instead of the copy as part of the website.

Fixes #3